### PR TITLE
v0.1.5: macOS 26 Tahoe stability fixes & UI polish

### DIFF
--- a/AiTranscribe/AiTranscribe.xcodeproj/project.pbxproj
+++ b/AiTranscribe/AiTranscribe.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		1E1391072F1FF2900070C41D /* Icon-iOS-Default-256x256@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-iOS-Default-256x256@1x.png"; sourceTree = "<group>"; };
 		1E1391082F1FF2900070C41D /* IMPLEMENTATION_CHECKLIST.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = IMPLEMENTATION_CHECKLIST.md; sourceTree = "<group>"; };
 		1E1391092F1FF2900070C41D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1E13920B2F20A00B0070C41D /* FloatingIndicatorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingIndicatorWindow.swift; sourceTree = "<group>"; };
 		1E13910A2F1FF2900070C41D /* KeyboardSimulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSimulator.swift; sourceTree = "<group>"; };
 		1E13910B2F1FF2900070C41D /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		1E13910C2F1FF2900070C41D /* MicrophoneOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneOnboardingView.swift; sourceTree = "<group>"; };
@@ -206,6 +207,7 @@
 				1E1391022F1FF2900070C41D /* DELETE_DUPLICATES_INSTRUCTIONS.md */,
 				1E1391032F1FF2900070C41D /* FINAL_POLISH.md */,
 				1E1391042F1FF2900070C41D /* FIXES_SUMMARY.md */,
+				1E13920B2F20A00B0070C41D /* FloatingIndicatorWindow.swift */,
 				1E1391052F1FF2900070C41D /* HistoryManager.swift */,
 				1E1391062F1FF2900070C41D /* HotkeyManager.swift */,
 				1E1391072F1FF2900070C41D /* Icon-iOS-Default-256x256@1x.png */,
@@ -600,6 +602,7 @@
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "AiTranscribe/AiTranscribe-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
@@ -648,6 +651,7 @@
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "AiTranscribe/AiTranscribe-Bridging-Header.h";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 			};

--- a/AiTranscribe/AiTranscribe/AiTranscribe-Bridging-Header.h
+++ b/AiTranscribe/AiTranscribe/AiTranscribe-Bridging-Header.h
@@ -1,0 +1,8 @@
+//
+//  AiTranscribe-Bridging-Header.h
+//  AiTranscribe
+//
+//  Bridging header to expose Objective-C helpers to Swift.
+//
+
+#import "ObjCExceptionCatcher.h"

--- a/AiTranscribe/AiTranscribe/AiTranscribeApp.swift
+++ b/AiTranscribe/AiTranscribe/AiTranscribeApp.swift
@@ -29,19 +29,20 @@ import AVFoundation
 
 @main
 struct AiTranscribeApp: App {
-    @StateObject private var appState = AppState()
-    @StateObject private var sessionManager = SessionManager()
-    /// Use the shared singleton BackendManager
+    /// Use shared singletons so AppDelegate can access them at launch
+    @ObservedObject private var appState = AppState.shared
+    @ObservedObject private var sessionManager = SessionManager.shared
     @ObservedObject private var backendManager = BackendManager.shared
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     @State private var hotkeysRegistered = false
-    @State private var isInitialized = false
 
     init() {
         // Force singleton creation early to ensure backend starts
-        print("AiTranscribeApp.init() - BackendManager.shared accessed")
+        print("AiTranscribeApp.init() - singletons created")
         _ = BackendManager.shared
+        _ = AppState.shared
+        _ = SessionManager.shared
     }
 
     var body: some Scene {
@@ -51,12 +52,6 @@ struct AiTranscribeApp: App {
                 .environmentObject(backendManager)
                 .environmentObject(sessionManager)
                 .task {
-                    // Initialize once when the view appears
-                    if !isInitialized {
-                        isInitialized = true
-                        await initializeApp()
-                    }
-
                     if !hotkeysRegistered {
                         HotkeyManager.shared.setup(appState: appState)
                         hotkeysRegistered = true
@@ -72,39 +67,6 @@ struct AiTranscribeApp: App {
                 .environmentObject(backendManager)
                 .environmentObject(sessionManager)
         }
-    }
-
-    /// Initialize the app - bindings, onboarding, model loading
-    @MainActor
-    private func initializeApp() async {
-        print("AiTranscribeApp: Initializing...")
-
-        // Bind state synchronization
-        appState.bindToBackendManager(backendManager)
-
-        // Store references in AppDelegate
-        appDelegate.configure(appState: appState, backendManager: backendManager)
-        appDelegate.configureSessionManager(sessionManager)
-
-        // Show onboarding if needed
-        let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
-        if !hasCompletedOnboarding {
-            appDelegate.showOnboarding(appState: appState, backendManager: backendManager)
-        }
-
-        // Wire session manager to app state for mutual exclusion
-        sessionManager.appState = appState
-
-        // Load saved sessions
-        sessionManager.loadSessions()
-
-        // Wait for server ready and fetch status (model loads on-demand when recording starts)
-        await backendManager.waitForServerReady()
-        if backendManager.isServerReady {
-            await appState.checkServerStatus()
-        }
-
-        print("AiTranscribeApp: Initialization complete")
     }
 
     @MainActor private var menuBarIcon: String {

--- a/AiTranscribe/AiTranscribe/AppDelegate.swift
+++ b/AiTranscribe/AiTranscribe/AppDelegate.swift
@@ -2,44 +2,64 @@ import SwiftUI
 import AppKit
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-    private var appState: AppState?
-    private var backendManager: BackendManager?
-    private var sessionManager: SessionManager?
     private var onboardingWindowController: OnboardingWindowController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         print("AppDelegate: applicationDidFinishLaunching")
-        // Backend initialization is now handled in MenuBarView.task
-    }
 
-    func configure(appState: AppState, backendManager: BackendManager) {
-        print("AppDelegate.configure() - storing references")
-        self.appState = appState
-        self.backendManager = backendManager
+        // Fix macOS 26 Tahoe bug: NSHostingView triggers re-entrant _postWindowNeeds*
+        // calls during the display cycle, crashing ANY window with SwiftUI content.
+        DisplayCycleFix.install()
 
+        // Use singletons — available immediately, no need to wait for SwiftUI
+        let appState = AppState.shared
+        let backendManager = BackendManager.shared
+        let sessionManager = SessionManager.shared
+
+        // Bind state synchronization
+        appState.bindToBackendManager(backendManager)
+
+        // Wire session manager to app state for mutual exclusion
+        sessionManager.appState = appState
+
+        // Load saved sessions
+        sessionManager.loadSessions()
+
+        // Show onboarding if needed — immediately on launch, no click required
+        let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+        if !hasCompletedOnboarding {
+            showOnboarding(appState: appState, backendManager: backendManager)
+        }
+
+        // Monitor onboarding completion
         UserDefaults.standard.addObserver(
             self,
             forKeyPath: "hasCompletedOnboarding",
             options: [.new],
             context: nil
         )
-    }
 
-    /// Store session manager reference for graceful shutdown
-    func configureSessionManager(_ sessionManager: SessionManager) {
-        self.sessionManager = sessionManager
+        // Background: wait for server ready, then fetch status
+        Task { @MainActor in
+            // Health check will detect readiness (no timeout wall)
+            while !backendManager.isServerReady {
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+            await appState.checkServerStatus()
+            print("AppDelegate: Server ready, initial status fetched")
+        }
     }
 
     /// Gracefully stop session recording before app quits
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        guard let sessionManager, sessionManager.isSessionRecording else {
+        let sessionManager = SessionManager.shared
+        guard sessionManager.isSessionRecording else {
             return .terminateNow
         }
 
         // Stop session recording before quitting
         Task { @MainActor in
             await sessionManager.stopSessionRecording()
-            // Small delay to let file finalize, then quit
             try? await Task.sleep(for: .milliseconds(500))
             NSApplication.shared.reply(toApplicationShouldTerminate: true)
         }
@@ -47,7 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return .terminateLater
     }
 
-    /// Show onboarding window (called from SwiftUI)
+    /// Show onboarding window
     func showOnboarding(appState: AppState, backendManager: BackendManager) {
         print("AppDelegate.showOnboarding() - showing onboarding window")
         let controller = OnboardingWindowController()

--- a/AiTranscribe/AiTranscribe/AppState.swift
+++ b/AiTranscribe/AiTranscribe/AppState.swift
@@ -38,6 +38,9 @@ import Combine  // Apple's framework for reactive programming
 @MainActor
 class AppState: ObservableObject {
 
+    /// Shared singleton so AppDelegate can access it at launch (for onboarding)
+    static let shared = AppState()
+
     // =========================================================================
     // PUBLISHED PROPERTIES - Changes trigger UI updates
     // =========================================================================
@@ -512,6 +515,12 @@ class AppState: ObservableObject {
     func fetchAvailableModels() async {
         do {
             availableModels = try await apiClient.listModels()
+            // Force all windows to redisplay — on macOS 26 Tahoe, @Published
+            // changes can fail to trigger SwiftUI view updates due to the
+            // display cycle exception (caught by DisplayCycleFix).
+            for window in NSApp.windows {
+                window.display()
+            }
         } catch {
             print("Failed to fetch models: \(error)")
         }

--- a/AiTranscribe/AiTranscribe/BackendManager.swift
+++ b/AiTranscribe/AiTranscribe/BackendManager.swift
@@ -752,12 +752,19 @@ class BackendManager: ObservableObject {
     // HEALTH MONITORING
     // =========================================================================
 
-    /// Start periodic health checks
+    /// Start periodic health checks.
+    /// Uses a shorter interval (2s) until the server is ready, then switches to 5s.
     private func startHealthCheck() {
         healthCheckTimer?.invalidate()
-        healthCheckTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+        let interval: TimeInterval = isServerReady ? 5.0 : 2.0
+        healthCheckTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.checkHealth()
+                guard let self else { return }
+                self.checkHealth()
+                // Once server becomes ready, slow down to 5s interval
+                if self.isServerReady {
+                    self.startHealthCheck()
+                }
             }
         }
     }
@@ -774,7 +781,7 @@ class BackendManager: ObservableObject {
         startHealthCheck()
     }
 
-    /// Check if the process is still healthy
+    /// Check if the process is still healthy and if the server is responding
     private func checkHealth() {
         guard let process = process else {
             isRunning = false
@@ -787,6 +794,26 @@ class BackendManager: ObservableObject {
             isServerReady = false
             if !isIntentionallyStopping {
                 handleUnexpectedTermination()
+            }
+            return
+        }
+
+        // If running but not yet marked as ready, poll the health endpoint
+        if !isServerReady {
+            Task {
+                do {
+                    let url = URL(string: "http://localhost:8765/health")!
+                    let (_, response) = try await URLSession.shared.data(from: url)
+                    if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
+                        await MainActor.run {
+                            self.isServerReady = true
+                            self.statusMessage = "Ready - \(self.currentBackendMode.displayName)"
+                            self.addLog("Server is ready (detected by health check)", level: .info)
+                        }
+                    }
+                } catch {
+                    // Server not ready yet, will retry on next health check
+                }
             }
         }
     }

--- a/AiTranscribe/AiTranscribe/FloatingIndicatorWindow.swift
+++ b/AiTranscribe/AiTranscribe/FloatingIndicatorWindow.swift
@@ -1,0 +1,99 @@
+import AppKit
+import ObjectiveC
+
+// MARK: - Global Display Cycle Fix (macOS 26 Tahoe)
+
+/// Fixes a macOS 26 Tahoe bug where NSHostingView triggers re-entrant calls to
+/// private `_postWindowNeeds*` methods during AppKit's display cycle, causing
+/// NSException → SIGABRT on ANY window containing SwiftUI content.
+///
+/// The bug: During `displayIfNeeded`, AppKit calls `layoutIfNeeded` which posts
+/// `windowDidLayout`. NSHostingView observes this and calls `updateAnimatedWindowSize`
+/// or `updateConstraints`, which call `setNeedsDisplay/Layout/UpdateConstraints` on
+/// views. These propagate to the window's `_postWindowNeeds*` methods, which throw
+/// NSException because they detect a re-entrant update during an active display cycle.
+///
+/// The fix: Swizzle the three `_postWindowNeeds*` methods to call the original
+/// implementation inside an Objective-C @try/@catch block. If the original throws
+/// (re-entrant display cycle), the exception is caught and a DEFERRED update is
+/// scheduled on the next run loop iteration (outside the display cycle). If the
+/// original succeeds (normal operation), behavior is 100% unchanged.
+///
+/// Evidence from crash logs:
+/// - CrashLog 1-3: _postWindowNeedsUpdateConstraints throws (floating indicator)
+/// - CrashLog 4: _postWindowNeedsLayout throws (floating indicator)
+/// - CrashLog 6: _postWindowNeedsDisplay throws (Settings window)
+class DisplayCycleFix {
+
+    /// Call once at app launch (in AppDelegate.applicationDidFinishLaunching).
+    static func install() {
+        swizzle("_postWindowNeedsDisplay", with: #selector(NSWindow.safe_postWindowNeedsDisplay))
+        swizzle("_postWindowNeedsUpdateConstraints", with: #selector(NSWindow.safe_postWindowNeedsUpdateConstraints))
+        swizzle("_postWindowNeedsLayout", with: #selector(NSWindow.safe_postWindowNeedsLayout))
+    }
+
+    private static func swizzle(_ originalName: String, with swizzledSelector: Selector) {
+        let originalSelector = NSSelectorFromString(originalName)
+        guard let originalMethod = class_getInstanceMethod(NSWindow.self, originalSelector),
+              let swizzledMethod = class_getInstanceMethod(NSWindow.self, swizzledSelector) else {
+            print("DisplayCycleFix: could not find method \(originalName) — skipping")
+            return
+        }
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+}
+
+// MARK: - NSWindow swizzled methods
+
+extension NSWindow {
+
+    /// Swizzled `_postWindowNeedsDisplay`: calls original, catches NSException if it throws.
+    /// On catch: schedules a deferred display on the next run loop pass so the update
+    /// isn't lost (fixes frozen timer on M2 Macs where the exception fires every frame).
+    @objc func safe_postWindowNeedsDisplay() {
+        let success = ObjCExceptionCatcher.tryExecute {
+            self.safe_postWindowNeedsDisplay() // After swizzle, calls the original
+        }
+        if !success {
+            // Re-entrant call threw — schedule display outside the display cycle
+            DispatchQueue.main.async { [weak self] in
+                self?.contentView?.needsDisplay = true
+            }
+        }
+    }
+
+    /// Swizzled `_postWindowNeedsUpdateConstraints`: calls original, catches NSException.
+    /// On catch: schedules deferred constraint update.
+    @objc func safe_postWindowNeedsUpdateConstraints() {
+        let success = ObjCExceptionCatcher.tryExecute {
+            self.safe_postWindowNeedsUpdateConstraints() // After swizzle, calls the original
+        }
+        if !success {
+            DispatchQueue.main.async { [weak self] in
+                self?.contentView?.needsUpdateConstraints = true
+            }
+        }
+    }
+
+    /// Swizzled `_postWindowNeedsLayout`: calls original, catches NSException.
+    /// On catch: schedules deferred layout.
+    @objc func safe_postWindowNeedsLayout() {
+        let success = ObjCExceptionCatcher.tryExecute {
+            self.safe_postWindowNeedsLayout() // After swizzle, calls the original
+        }
+        if !success {
+            DispatchQueue.main.async { [weak self] in
+                self?.contentView?.needsLayout = true
+            }
+        }
+    }
+}
+
+// MARK: - FloatingIndicatorWindow
+
+/// A custom NSWindow subclass for floating indicator windows (recording indicator,
+/// session indicator, snap placeholders). This is now a marker class — the global
+/// DisplayCycleFix swizzle handles crash prevention for ALL windows via ObjC
+/// try/catch with deferred updates.
+class FloatingIndicatorWindow: NSWindow {
+}

--- a/AiTranscribe/AiTranscribe/HotkeyManager.swift
+++ b/AiTranscribe/AiTranscribe/HotkeyManager.swift
@@ -59,23 +59,23 @@ class HotkeyManager {
         installEventHandler()
 
         // Read shortcuts from UserDefaults
-        let toggleShortcut = UserDefaults.standard.string(forKey: "toggleRecordingShortcut") ?? "⌥Space"
-        let cancelShortcut = UserDefaults.standard.string(forKey: "cancelRecordingShortcut") ?? "Escape"
+        let toggleShortcut = UserDefaults.standard.string(forKey: "toggleRecordingShortcut") ?? "⌃P"
+        let cancelShortcut = UserDefaults.standard.string(forKey: "cancelRecordingShortcut") ?? "⌃K"
 
-        // Register Option+Space for toggle recording
+        // Register Control+P for toggle recording
         if let (keyCode, modifiers) = parseShortcut(toggleShortcut) {
             registerHotkey(id: .toggleRecording, keyCode: keyCode, modifiers: modifiers)
         } else {
-            // Default: Option+Space
-            registerHotkey(id: .toggleRecording, keyCode: UInt32(kVK_Space), modifiers: UInt32(optionKey))
+            // Default: Control+P
+            registerHotkey(id: .toggleRecording, keyCode: UInt32(kVK_ANSI_P), modifiers: UInt32(controlKey))
         }
 
-        // Register Option+Escape for cancel (Escape alone cannot be a global hotkey)
+        // Register Control+K for cancel recording
         if let (keyCode, modifiers) = parseShortcut(cancelShortcut) {
             registerHotkey(id: .cancelRecording, keyCode: keyCode, modifiers: modifiers)
         } else {
-            // Default: Option+Escape
-            registerHotkey(id: .cancelRecording, keyCode: UInt32(kVK_Escape), modifiers: UInt32(optionKey))
+            // Default: Control+K
+            registerHotkey(id: .cancelRecording, keyCode: UInt32(kVK_ANSI_K), modifiers: UInt32(controlKey))
         }
     }
 

--- a/AiTranscribe/AiTranscribe/MenuBarView.swift
+++ b/AiTranscribe/AiTranscribe/MenuBarView.swift
@@ -239,7 +239,7 @@ struct MenuBarView: View {
                 } label: {
                     Label("Record Session", systemImage: "waveform.badge.plus")
                 }
-                .disabled(!appState.isServerConnected || appState.isRecording)
+                .disabled(appState.isRecording)
             }
         }
         .padding(.horizontal, 12)
@@ -325,7 +325,7 @@ struct MenuBarView: View {
                 .padding(.vertical, 4)
 
             // Version
-            Text("AiTranscribe v0.1.2")
+            Text("AiTranscribe v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.5")")
                 .font(.caption)
                 .foregroundColor(.secondary)
 

--- a/AiTranscribe/AiTranscribe/ModelsOnboardingView.swift
+++ b/AiTranscribe/AiTranscribe/ModelsOnboardingView.swift
@@ -128,6 +128,23 @@ struct ModelsOnboardingView: View {
                 Text(downloadError ?? "An unknown error occurred")
             }
             
+            // Backend status banner
+            if !backendManager.isServerReady {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Backend is starting — downloads will be available shortly...")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .frame(maxWidth: .infinity)
+                .background(Color.orange.opacity(0.1))
+                .cornerRadius(8)
+                .padding(.horizontal, 40)
+            }
+
             // Model List - SCROLLABLE to prevent pushing buttons
             ScrollView {
                 VStack(spacing: 16) {
@@ -138,6 +155,7 @@ struct ModelsOnboardingView: View {
                             isLoading: loadingModels.contains(model.id),
                             isDownloaded: downloadedModels.contains(model.id) || isModelAlreadyDownloaded(model.id),
                             nemoAvailable: effectiveNemoAvailable,
+                            backendReady: backendManager.isServerReady,
                             onDownload: {
                                 // Check if NeMo is required but not available
                                 if model.requiresNemo && !effectiveNemoAvailable {
@@ -371,6 +389,7 @@ struct OnboardingModelCard: View {
     let isLoading: Bool
     let isDownloaded: Bool
     let nemoAvailable: Bool
+    let backendReady: Bool
     let onDownload: () -> Void
     let onInstallNemo: () -> Void
 
@@ -528,7 +547,7 @@ struct OnboardingModelCard: View {
             )
         }
         .buttonStyle(.plain)
-        .disabled(isDownloading || isDownloaded || isLoading)
+        .disabled(isDownloading || isDownloaded || isLoading || !backendReady)
         .help(helpText)
     }
 

--- a/AiTranscribe/AiTranscribe/ObjCExceptionCatcher.h
+++ b/AiTranscribe/AiTranscribe/ObjCExceptionCatcher.h
@@ -1,0 +1,20 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Lightweight Objective-C exception catcher for use from Swift.
+/// Swift cannot catch NSException — this helper bridges that gap.
+@interface ObjCExceptionCatcher : NSObject
+
+/// Executes the block. Returns YES if it completed normally,
+/// NO if an NSException was thrown (exception is silently caught).
++ (BOOL)tryExecute:(void (NS_NOESCAPE ^)(void))block;
+
+/// Executes the block. If an NSException is thrown, calls the catch block
+/// with the exception and returns NO.
++ (BOOL)tryExecute:(void (NS_NOESCAPE ^)(void))block
+           onCatch:(void (NS_NOESCAPE ^ _Nullable)(NSException *exception))catchBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AiTranscribe/AiTranscribe/ObjCExceptionCatcher.m
+++ b/AiTranscribe/AiTranscribe/ObjCExceptionCatcher.m
@@ -1,0 +1,23 @@
+#import "ObjCExceptionCatcher.h"
+
+@implementation ObjCExceptionCatcher
+
++ (BOOL)tryExecute:(void (NS_NOESCAPE ^)(void))block {
+    return [self tryExecute:block onCatch:nil];
+}
+
++ (BOOL)tryExecute:(void (NS_NOESCAPE ^)(void))block
+           onCatch:(void (NS_NOESCAPE ^ _Nullable)(NSException *exception))catchBlock {
+    @try {
+        block();
+        return YES;
+    }
+    @catch (NSException *exception) {
+        if (catchBlock) {
+            catchBlock(exception);
+        }
+        return NO;
+    }
+}
+
+@end

--- a/AiTranscribe/AiTranscribe/ReadyOnboardingView.swift
+++ b/AiTranscribe/AiTranscribe/ReadyOnboardingView.swift
@@ -17,7 +17,7 @@ struct ReadyOnboardingView: View {
     let onFinish: () -> Void
     
     @EnvironmentObject var appState: AppState
-    @AppStorage("toggleRecordingShortcut") private var toggleShortcut = "⌥Space"
+    @AppStorage("toggleRecordingShortcut") private var toggleShortcut = "⌃P"
     
     var body: some View {
         VStack(spacing: 0) {

--- a/AiTranscribe/AiTranscribe/RecordingIndicator.swift
+++ b/AiTranscribe/AiTranscribe/RecordingIndicator.swift
@@ -514,14 +514,14 @@ class SnapPlaceholderController {
         let contentView = SnapPlaceholderView(isHighlighted: highlighted)
         let hostingView = NSHostingView(rootView: contentView)
         hostingView.frame = CGRect(x: 0, y: 0, width: 70, height: 42)
+        if #available(macOS 13.0, *) { hostingView.sizingOptions = [] }
 
-        let window = NSWindow(
+        let window = FloatingIndicatorWindow(
             contentRect: hostingView.frame,
             styleMask: [.borderless],
             backing: .buffered,
             defer: false
         )
-
         window.contentView = hostingView
         window.isOpaque = false
         window.backgroundColor = .clear
@@ -536,6 +536,7 @@ class SnapPlaceholderController {
         let contentView = SnapPlaceholderView(isHighlighted: highlighted)
         let hostingView = NSHostingView(rootView: contentView)
         hostingView.frame = window.contentView?.frame ?? CGRect(x: 0, y: 0, width: 70, height: 42)
+        if #available(macOS 13.0, *) { hostingView.sizingOptions = [] }
         window.contentView = hostingView
     }
 }
@@ -780,6 +781,9 @@ class RecordingIndicatorController: NSObject, ObservableObject, NSWindowDelegate
         // Update on main thread
         DispatchQueue.main.async { [weak self] in
             self?.currentVolume = volume
+            // Force window to redraw — on macOS 26, SwiftUI's reactive update
+            // pipeline can fail silently (caught by DisplayCycleFix).
+            self?.window?.display()
         }
     }
 
@@ -790,11 +794,21 @@ class RecordingIndicatorController: NSObject, ObservableObject, NSWindowDelegate
         let hostingView = NSHostingView(rootView: contentView)
         hostingView.frame = CGRect(x: 0, y: 0, width: 70, height: 42)
 
+        // Prevent NSHostingView from trying to auto-update the window's
+        // content size min/max. This crashes on borderless floating windows
+        // because the constraint system throws an NSException.
+        if #available(macOS 13.0, *) {
+            hostingView.sizingOptions = []
+        }
+
         // Ensure the hosting view layer is fully transparent — prevents rectangular box artifact
         hostingView.wantsLayer = true
         hostingView.layer?.backgroundColor = .clear
 
-        let window = NSWindow(
+        // Use FloatingIndicatorWindow to prevent the NSHostingView constraint crash
+        // on macOS 26 Tahoe. It overrides _postWindowNeedsUpdateConstraints to be a
+        // no-op, preventing the NSException that crashes borderless floating windows.
+        let window = FloatingIndicatorWindow(
             contentRect: hostingView.frame,
             styleMask: [.borderless],
             backing: .buffered,
@@ -804,10 +818,10 @@ class RecordingIndicatorController: NSObject, ObservableObject, NSWindowDelegate
         window.contentView = hostingView
         window.isOpaque = false
         window.backgroundColor = .clear
-        window.hasShadow = false  // Disable window-level rectangular shadow
-        window.level = .floating  // Always on top
+        window.hasShadow = false
+        window.level = .floating
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        window.isMovableByWindowBackground = true  // Can drag to reposition
+        window.isMovableByWindowBackground = true
         window.ignoresMouseEvents = false
 
         // Force the window's content view to be fully transparent at the AppKit level

--- a/AiTranscribe/AiTranscribe/Sessions/SessionIndicatorView.swift
+++ b/AiTranscribe/AiTranscribe/Sessions/SessionIndicatorView.swift
@@ -6,104 +6,38 @@
  Wider than the quick-transcribe indicator, with a pulsing red dot
  and HH:MM:SS timer display.
 
- Follows the same visual language and window management pattern
- as RecordingIndicator.swift but with a calmer, session-focused design.
+ ARCHITECTURE NOTE:
+ ------------------
+ On macOS 26 Tahoe, NSHostingView's SwiftUI rendering pipeline fails on
+ borderless floating windows because _postWindowNeedsDisplay throws during
+ layout. This prevents SwiftUI from ever re-rendering — the initial render
+ works but no updates are possible.
+
+ To work around this, the session indicator is built entirely with Core
+ Animation (CALayer + CATextLayer + CAShapeLayer). Core Animation renders
+ through the GPU compositor, completely bypassing AppKit's view display
+ system and the broken _postWindowNeedsDisplay path. Timer updates go
+ directly to CATextLayer.string, which Core Animation composites immediately.
  */
 
-import SwiftUI
 import AppKit
 import Combine
-
-// =============================================================================
-// SESSION INDICATOR VIEW
-// =============================================================================
-
-struct SessionIndicatorView: View {
-    @ObservedObject var controller: SessionIndicatorController
-
-    @State private var dotOpacity: Double = 1.0
-    @State private var appearScale: CGFloat = 0.3
-    @State private var appearOpacity: Double = 0
-
-    @Environment(\.colorScheme) private var colorScheme
-
-    var body: some View {
-        HStack(spacing: 8) {
-            if controller.isProcessing {
-                // Processing state: spinner + text
-                ProgressView()
-                    .scaleEffect(0.6)
-                    .frame(width: 12, height: 12)
-                Text("Processing...")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(colorScheme == .dark ? .white : .primary)
-            } else {
-                // Recording state: pulsing red dot + timer
-                Circle()
-                    .fill(.red)
-                    .frame(width: 8, height: 8)
-                    .opacity(dotOpacity)
-
-                Text(SessionManager.formatDurationHHMMSS(controller.duration))
-                    .font(.system(size: 13, weight: .medium, design: .monospaced))
-                    .foregroundColor(colorScheme == .dark ? .white : .primary)
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        .background(
-            Capsule()
-                .fill(
-                    colorScheme == .dark
-                        ? Color(white: 0.15, opacity: 0.65)
-                        : Color(white: 0.92, opacity: 0.85)
-                )
-        )
-        .overlay(
-            Capsule()
-                .stroke(
-                    colorScheme == .dark
-                        ? Color.white.opacity(0.15)
-                        : Color.black.opacity(0.1),
-                    lineWidth: 0.5
-                )
-        )
-        .scaleEffect(appearScale)
-        .opacity(appearOpacity)
-        .onAppear {
-            // Appear animation
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) {
-                    appearScale = 1.0
-                    appearOpacity = 1.0
-                }
-            }
-
-            // Subtle pulsing red dot (slower than recording indicator)
-            withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
-                dotOpacity = 0.3
-            }
-        }
-        .onChange(of: controller.isDisappearing) { _, isDisappearing in
-            if isDisappearing {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    appearScale = 0.3
-                    appearOpacity = 0
-                }
-            }
-        }
-    }
-}
+import QuartzCore
 
 // =============================================================================
 // SESSION INDICATOR CONTROLLER
 // =============================================================================
 
 /// Manages the floating session indicator window.
-/// Follows the same pattern as RecordingIndicatorController but simplified.
+/// Uses pure Core Animation layers (no SwiftUI) for macOS 26 Tahoe compatibility.
 class SessionIndicatorController: NSObject, ObservableObject, NSWindowDelegate {
     private var window: NSWindow?
     private var durationTimer: Timer?
+
+    // Core Animation layers
+    private var containerLayer: CALayer?
+    private var dotLayer: CALayer?
+    private var timerLayer: CATextLayer?
 
     /// Snap placeholder controller for drag-and-snap (reuses existing snap system)
     private let snapPlaceholders = SessionSnapPlaceholderController()
@@ -139,20 +73,40 @@ class SessionIndicatorController: NSObject, ObservableObject, NSWindowDelegate {
             window?.orderOut(nil)
             window = nil
         }
+        dotLayer = nil
+        timerLayer = nil
+        containerLayer = nil
 
         duration = 0
         isDisappearing = false
+        isProcessing = false
         createWindow()
         updatePosition()
         window?.orderFront(nil)
         isVisible = true
 
+        // Appear animation (spring scale + fade)
+        if let layer = window?.contentView?.layer {
+            layer.opacity = 0
+            layer.transform = CATransform3DMakeScale(0.3, 0.3, 1.0)
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                CATransaction.begin()
+                CATransaction.setAnimationDuration(0.4)
+                CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
+
+                layer.opacity = 1.0
+                layer.transform = CATransform3DIdentity
+
+                CATransaction.commit()
+            }
+        }
+
         // Start timer to update duration every second
         durationTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             guard let self else { return }
-            DispatchQueue.main.async {
-                self.duration += 1
-            }
+            self.duration += 1
+            self.updateTimerText()
         }
         if let timer = durationTimer {
             RunLoop.main.add(timer, forMode: .common)
@@ -165,6 +119,15 @@ class SessionIndicatorController: NSObject, ObservableObject, NSWindowDelegate {
         durationTimer?.invalidate()
         durationTimer = nil
         isProcessing = true
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        // Hide the red dot and shift text left to use the freed space
+        dotLayer?.isHidden = true
+        timerLayer?.frame = CGRect(x: 14, y: 9, width: 84, height: 18)
+        CATransaction.commit()
+
+        updateTimerText()
     }
 
     func hide() {
@@ -175,7 +138,22 @@ class SessionIndicatorController: NSObject, ObservableObject, NSWindowDelegate {
         isProcessing = false
         isDisappearing = true
 
+        // Disappear animation (scale down + fade out)
+        if let layer = window?.contentView?.layer {
+            CATransaction.begin()
+            CATransaction.setAnimationDuration(0.3)
+            CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
+
+            layer.opacity = 0
+            layer.transform = CATransform3DMakeScale(0.3, 0.3, 1.0)
+
+            CATransaction.commit()
+        }
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+            self?.dotLayer = nil
+            self?.timerLayer = nil
+            self?.containerLayer = nil
             self?.window?.orderOut(nil)
             self?.window = nil
             self?.isVisible = false
@@ -187,6 +165,32 @@ class SessionIndicatorController: NSObject, ObservableObject, NSWindowDelegate {
     /// Sync duration from SessionManager (call from outside when duration updates)
     func updateDuration(_ newDuration: TimeInterval) {
         duration = newDuration
+    }
+
+    // MARK: - Timer Text
+
+    private func updateTimerText() {
+        let text = isProcessing
+            ? "Processing..."
+            : SessionManager.formatDurationHHMMSS(duration)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)  // No implicit animation on text change
+        timerLayer?.string = makeAttributedString(text)
+        CATransaction.commit()
+    }
+
+    private func makeAttributedString(_ text: String) -> NSAttributedString {
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let font = isProcessing
+            ? NSFont.systemFont(ofSize: 13, weight: .medium)
+            : NSFont.monospacedSystemFont(ofSize: 13, weight: .medium)
+        let color = isDark ? NSColor.white : NSColor.labelColor
+
+        return NSAttributedString(string: text, attributes: [
+            .font: font,
+            .foregroundColor: color
+        ])
     }
 
     // MARK: - Drag and Snap
@@ -237,21 +241,80 @@ class SessionIndicatorController: NSObject, ObservableObject, NSWindowDelegate {
     // MARK: - Window Management
 
     private func createWindow() {
-        let contentView = SessionIndicatorView(controller: self)
-        let hostingView = NSHostingView(rootView: contentView)
-        hostingView.frame = CGRect(x: 0, y: 0, width: 140, height: 36)
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let scale = NSScreen.main?.backingScaleFactor ?? 2.0
+        let windowWidth: CGFloat = 110
+        let windowHeight: CGFloat = 36
 
-        hostingView.wantsLayer = true
-        hostingView.layer?.backgroundColor = .clear
+        // Container NSView — pure layer-backed, no SwiftUI
+        let container = NSView(frame: CGRect(x: 0, y: 0, width: windowWidth, height: windowHeight))
+        container.wantsLayer = true
+        container.layer?.backgroundColor = .clear
 
-        let window = NSWindow(
-            contentRect: hostingView.frame,
+        // --- Capsule background ---
+        let bgLayer = CALayer()
+        bgLayer.frame = container.bounds
+        bgLayer.cornerRadius = windowHeight / 2  // Makes it a capsule
+        bgLayer.backgroundColor = isDark
+            ? NSColor(white: 0.15, alpha: 0.65).cgColor
+            : NSColor(white: 0.92, alpha: 0.85).cgColor
+        container.layer?.addSublayer(bgLayer)
+
+        // --- Capsule border ---
+        let borderLayer = CAShapeLayer()
+        let borderRect = container.bounds.insetBy(dx: 0.25, dy: 0.25)
+        borderLayer.path = CGPath(roundedRect: borderRect,
+                                  cornerWidth: borderRect.height / 2,
+                                  cornerHeight: borderRect.height / 2,
+                                  transform: nil)
+        borderLayer.strokeColor = isDark
+            ? NSColor.white.withAlphaComponent(0.15).cgColor
+            : NSColor.black.withAlphaComponent(0.1).cgColor
+        borderLayer.fillColor = nil
+        borderLayer.lineWidth = 0.5
+        container.layer?.addSublayer(borderLayer)
+
+        // --- Red dot (pulsing) ---
+        let dot = CALayer()
+        dot.frame = CGRect(x: 14, y: (windowHeight - 8) / 2, width: 8, height: 8)
+        dot.cornerRadius = 4
+        dot.backgroundColor = NSColor.red.cgColor
+        container.layer?.addSublayer(dot)
+        self.dotLayer = dot
+
+        // Pulsing animation
+        let pulse = CABasicAnimation(keyPath: "opacity")
+        pulse.fromValue = 1.0
+        pulse.toValue = 0.3
+        pulse.duration = 1.5
+        pulse.autoreverses = true
+        pulse.repeatCount = .infinity
+        pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        dot.add(pulse, forKey: "pulse")
+
+        // --- Timer text ---
+        let textLayer = CATextLayer()
+        textLayer.string = makeAttributedString("00:00:00")
+        // Position: after dot (8) + spacing (8), starting at x=30
+        // Vertically centered: (36 - 18) / 2 = 9
+        textLayer.frame = CGRect(x: 30, y: 9, width: 68, height: 18)
+        textLayer.alignmentMode = .left
+        textLayer.contentsScale = scale
+        textLayer.truncationMode = .end
+        container.layer?.addSublayer(textLayer)
+        self.timerLayer = textLayer
+
+        self.containerLayer = container.layer
+
+        // --- Window ---
+        let window = FloatingIndicatorWindow(
+            contentRect: container.frame,
             styleMask: [.borderless],
             backing: .buffered,
             defer: false
         )
 
-        window.contentView = hostingView
+        window.contentView = container
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
@@ -259,12 +322,6 @@ class SessionIndicatorController: NSObject, ObservableObject, NSWindowDelegate {
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         window.isMovableByWindowBackground = true
         window.ignoresMouseEvents = false
-
-        if let cv = window.contentView {
-            cv.wantsLayer = true
-            cv.layer?.backgroundColor = .clear
-            cv.layer?.isOpaque = false
-        }
 
         self.window = window
     }
@@ -312,7 +369,7 @@ class SessionSnapPlaceholderController {
     private var windows: [SessionIndicatorController.ScreenPosition: NSWindow] = [:]
     private var highlightedPosition: SessionIndicatorController.ScreenPosition?
 
-    private let windowWidth: CGFloat = 140
+    private let windowWidth: CGFloat = 110
     private let windowHeight: CGFloat = 36
 
     func show() {
@@ -388,23 +445,14 @@ class SessionSnapPlaceholderController {
     }
 
     private func createPlaceholderWindow(at origin: CGPoint) -> NSWindow {
-        let view = Capsule()
-            .fill(.ultraThinMaterial)
-            .opacity(0.4)
-            .overlay(Capsule().stroke(Color.white.opacity(0.2), lineWidth: 1))
-            .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 2)
-            .frame(width: windowWidth, height: windowHeight)
-
-        let hostingView = NSHostingView(rootView: view)
-        hostingView.frame = CGRect(x: 0, y: 0, width: windowWidth, height: windowHeight)
-
-        let window = NSWindow(
-            contentRect: hostingView.frame,
+        let view = createPlaceholderView(highlighted: false)
+        let window = FloatingIndicatorWindow(
+            contentRect: CGRect(x: 0, y: 0, width: windowWidth, height: windowHeight),
             styleMask: [.borderless],
             backing: .buffered,
             defer: false
         )
-        window.contentView = hostingView
+        window.contentView = view
         window.isOpaque = false
         window.backgroundColor = .clear
         window.level = .floating
@@ -414,16 +462,27 @@ class SessionSnapPlaceholderController {
     }
 
     private func updateWindowHighlight(_ window: NSWindow, highlighted: Bool) {
-        let view = Capsule()
-            .fill(.ultraThinMaterial)
-            .opacity(highlighted ? 0.9 : 0.4)
-            .overlay(Capsule().stroke(Color.white.opacity(highlighted ? 0.5 : 0.2), lineWidth: 1))
-            .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 2)
-            .frame(width: windowWidth, height: windowHeight)
-            .scaleEffect(highlighted ? 1.05 : 1.0)
+        let view = createPlaceholderView(highlighted: highlighted)
+        window.contentView = view
+    }
 
-        let hostingView = NSHostingView(rootView: view)
-        hostingView.frame = window.contentView?.frame ?? CGRect(x: 0, y: 0, width: windowWidth, height: windowHeight)
-        window.contentView = hostingView
+    /// Create a pure-AppKit placeholder view (no SwiftUI — avoids macOS 26 display issues)
+    private func createPlaceholderView(highlighted: Bool) -> NSView {
+        let view = NSView(frame: CGRect(x: 0, y: 0, width: windowWidth, height: windowHeight))
+        view.wantsLayer = true
+        view.layer?.backgroundColor = .clear
+
+        let bg = CALayer()
+        bg.frame = view.bounds
+        bg.cornerRadius = windowHeight / 2
+        bg.backgroundColor = NSColor(white: 0.5, alpha: highlighted ? 0.35 : 0.15).cgColor
+        bg.borderColor = NSColor.white.withAlphaComponent(highlighted ? 0.5 : 0.2).cgColor
+        bg.borderWidth = 1
+        if highlighted {
+            bg.transform = CATransform3DMakeScale(1.05, 1.05, 1.0)
+        }
+        view.layer?.addSublayer(bg)
+
+        return view
     }
 }

--- a/AiTranscribe/AiTranscribe/Sessions/SessionManager.swift
+++ b/AiTranscribe/AiTranscribe/Sessions/SessionManager.swift
@@ -206,6 +206,9 @@ private struct SessionMetadata: Codable {
 @MainActor
 class SessionManager: ObservableObject {
 
+    /// Shared singleton so AppDelegate can access it at launch
+    static let shared = SessionManager()
+
     // MARK: - Published State
 
     /// All sessions, sorted newest first

--- a/AiTranscribe/AiTranscribe/Sessions/SessionRecorder.swift
+++ b/AiTranscribe/AiTranscribe/Sessions/SessionRecorder.swift
@@ -38,6 +38,10 @@ import CoreMedia
 import CoreAudio
 import Combine
 
+#if canImport(AVFAudio)
+import AVFAudio
+#endif
+
 /// Records both system audio and microphone into a single M4A file
 class SessionRecorder: NSObject, ObservableObject {
 
@@ -75,6 +79,25 @@ class SessionRecorder: NSObject, ObservableObject {
     func startRecording(sessionDir: URL, micDeviceId: AudioDeviceID? = nil) async -> Bool {
         guard !isRecording else { return false }
 
+        // Check microphone permission BEFORE touching AVAudioEngine.
+        // Accessing engine.inputNode without permission causes a hard crash (ObjC exception).
+        let micPermission = AVCaptureDevice.authorizationStatus(for: .audio)
+        switch micPermission {
+        case .notDetermined:
+            let granted = await AVCaptureDevice.requestAccess(for: .audio)
+            if !granted {
+                print("SessionRecorder: Microphone permission denied by user")
+                return false
+            }
+        case .denied, .restricted:
+            print("SessionRecorder: Microphone permission not granted (status: \(micPermission.rawValue))")
+            return false
+        case .authorized:
+            break
+        @unknown default:
+            break
+        }
+
         let m4aURL = sessionDir.appendingPathComponent("audio.m4a")
         let micURL = sessionDir.appendingPathComponent("mic_temp.caf")
         let sysURL = sessionDir.appendingPathComponent("sys_temp.caf")
@@ -86,12 +109,21 @@ class SessionRecorder: NSObject, ObservableObject {
         sysFile = nil
         sysFileFormat = nil
 
-        // Start system audio capture
-        let systemStarted = await startSystemAudioCapture()
+        // System audio capture via ScreenCaptureKit.
+        // Only attempt if Screen Recording permission is already granted.
+        // ScreenCaptureKit can hard-crash on unsigned/quarantined apps,
+        // so we check permission first and skip entirely if not granted.
+        var systemStarted = false
+        let hasScreenPermission = SystemAudioCapture.preflightPermission()
+        if hasScreenPermission {
+            systemStarted = await startSystemAudioCapture()
+        } else {
+            print("SessionRecorder: Screen Recording permission not granted — skipping system audio")
+        }
         hasSystemAudio = systemStarted
 
         if !systemStarted {
-            print("SessionRecorder: System audio unavailable, recording mic-only")
+            print("SessionRecorder: Recording mic-only")
             tempSysURL = nil
         }
 
@@ -205,7 +237,14 @@ class SessionRecorder: NSObject, ObservableObject {
         systemCapture.onAudioBuffer = { [weak self] sampleBuffer in
             self?.handleSystemAudioBuffer(sampleBuffer)
         }
-        return await systemCapture.startCapture()
+        do {
+            return try await Task {
+                await systemCapture.startCapture()
+            }.value
+        } catch {
+            print("SessionRecorder: System audio capture failed unexpectedly: \(error)")
+            return false
+        }
     }
 
     /// Write system audio directly at native format — NO AVAudioConverter.

--- a/AiTranscribe/AiTranscribe/Sessions/SystemAudioCapture.swift
+++ b/AiTranscribe/AiTranscribe/Sessions/SystemAudioCapture.swift
@@ -49,17 +49,30 @@ class SystemAudioCapture: NSObject, ObservableObject {
 
     // MARK: - Permission Checking
 
-    /// Check if Screen Recording permission is granted.
+    /// Synchronous, crash-safe permission pre-check.
+    /// Only returns true on macOS 15+ where CGPreflightScreenCaptureAccess is available.
+    /// On older macOS, returns false (system audio skipped) to avoid SCShareableContent crashes.
+    static func preflightPermission() -> Bool {
+        if #available(macOS 15.0, *) {
+            return CGPreflightScreenCaptureAccess()
+        } else {
+            // On older macOS, we can't safely check without risking a crash
+            // on unsigned/quarantined apps. Skip system audio.
+            return false
+        }
+    }
+
+    /// Async permission check — used internally by startCapture().
     /// Uses CGPreflightScreenCaptureAccess on macOS 15+, falls back to SCShareableContent check.
     static func checkPermission() async -> Bool {
         if #available(macOS 15.0, *) {
             return CGPreflightScreenCaptureAccess()
         } else {
-            // On older macOS, try to enumerate shareable content — if it fails, permission not granted
             do {
                 _ = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
                 return true
             } catch {
+                print("SystemAudioCapture: Permission check failed: \(error)")
                 return false
             }
         }

--- a/AiTranscribe/AiTranscribe/Settings/AboutSettingsView.swift
+++ b/AiTranscribe/AiTranscribe/Settings/AboutSettingsView.swift
@@ -32,7 +32,7 @@ struct AboutView: View {
                 .fontWeight(.bold)
 
             // Version
-            Text("Version 0.1.2")
+            Text("Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.5")")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
 

--- a/AiTranscribe/AiTranscribe/Settings/ModelsSettingsView.swift
+++ b/AiTranscribe/AiTranscribe/Settings/ModelsSettingsView.swift
@@ -132,12 +132,11 @@ struct ModelsSettingsView: View {
                         .padding(.vertical, 40)
                     } else {
                         VStack(spacing: 12) {
-                            Image(systemName: "exclamationmark.triangle")
-                                .font(.largeTitle)
-                                .foregroundColor(.orange)
-                            Text("Backend not connected")
+                            ProgressView()
+                                .scaleEffect(1.2)
+                            Text("Server Starting...")
                                 .font(.headline)
-                            Text("Waiting for server to start...")
+                            Text("Models will appear once the backend is ready.")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }

--- a/AiTranscribe/AiTranscribe/Settings/SessionDetailView.swift
+++ b/AiTranscribe/AiTranscribe/Settings/SessionDetailView.swift
@@ -30,10 +30,11 @@ struct SessionDetailView: View {
         sessionManager.currentTranscribingSessionId == sessionId
     }
 
-    /// System RAM in GB (minus 4GB for OS)
+    /// System RAM in GB (minus 4GB for OS). Must exceed minRamBudget by at least
+    /// the slider step (0.5) to avoid SwiftUI Slider precondition failure.
     private var maxRamBudget: Double {
         let totalRAM = Double(ProcessInfo.processInfo.physicalMemory) / 1_073_741_824
-        return max(minRamBudget, totalRAM - 4)
+        return max(minRamBudget + 0.5, totalRAM - 4)
     }
 
     /// Minimum RAM budget = model RAM + 1GB buffer (can't go below what the model needs)
@@ -232,6 +233,21 @@ struct SessionDetailView: View {
             Text("Cannot transcribe — audio file has been deleted.")
                 .font(.caption)
                 .foregroundColor(.secondary)
+        } else if !appState.isServerConnected {
+            VStack(spacing: 10) {
+                ProgressView()
+                    .scaleEffect(0.9)
+                Text("Server Starting...")
+                    .font(.subheadline.bold())
+                Text("Transcription will be available once the backend is ready.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color.blue.opacity(0.05)))
+            .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.blue.opacity(0.2)))
         } else {
             notTranscribedControls(session)
         }

--- a/AiTranscribe/AiTranscribe/Settings/SettingsSidebar.swift
+++ b/AiTranscribe/AiTranscribe/Settings/SettingsSidebar.swift
@@ -87,7 +87,7 @@ struct SettingsSidebar: View {
             Spacer()
 
             // Version at bottom
-            Text("Version 0.1.2")
+            Text("Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.5")")
                 .font(.caption2)
                 .foregroundColor(.secondary.opacity(0.6))
                 .padding(.bottom, 16)

--- a/AiTranscribe/AiTranscribe/Settings/SettingsView.swift
+++ b/AiTranscribe/AiTranscribe/Settings/SettingsView.swift
@@ -44,11 +44,13 @@ struct SettingsView: View {
         }
         .frame(width: 1050, height: 720)
         .onAppear {
-            // Pause health check timer to prevent UI re-renders
-            backendManager.pauseHealthCheck()
+            // Only pause health checks if server is already ready
+            // (avoid pausing during startup — we need to detect readiness)
+            if backendManager.isServerReady {
+                backendManager.pauseHealthCheck()
+            }
         }
         .onDisappear {
-            // Resume health check timer when Settings window closes
             backendManager.resumeHealthCheck()
         }
     }

--- a/AiTranscribe/AiTranscribe/Settings/ShortcutsSettingsView.swift
+++ b/AiTranscribe/AiTranscribe/Settings/ShortcutsSettingsView.swift
@@ -4,8 +4,8 @@ import Carbon.HIToolbox
 // MARK: - Shortcuts Settings View
 
 struct ShortcutsSettingsView: View {
-    @AppStorage("toggleRecordingShortcut") private var toggleShortcut = "⌥Space"
-    @AppStorage("cancelRecordingShortcut") private var cancelShortcut = "⌥Escape"
+    @AppStorage("toggleRecordingShortcut") private var toggleShortcut = "⌃P"
+    @AppStorage("cancelRecordingShortcut") private var cancelShortcut = "⌃K"
 
     @State private var isRecordingToggleShortcut = false
     @State private var isRecordingCancelShortcut = false
@@ -42,7 +42,7 @@ struct ShortcutsSettingsView: View {
                 Text("Click a shortcut button and press your desired key combination.")
                     .font(.caption)
                     .foregroundColor(.secondary)
-                Text("Default: Option+Space to toggle, Option+Escape to cancel")
+                Text("Default: Control+P to toggle, Control+K to cancel")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }

--- a/AiTranscribe/AiTranscribe/ShortcutsOnboardingView.swift
+++ b/AiTranscribe/AiTranscribe/ShortcutsOnboardingView.swift
@@ -16,8 +16,8 @@ struct ShortcutsOnboardingView: View {
     let onNext: () -> Void
     let onBack: () -> Void
     
-    @AppStorage("toggleRecordingShortcut") private var toggleShortcut = "⌥Space"
-    @AppStorage("cancelRecordingShortcut") private var cancelShortcut = "⌥Escape"
+    @AppStorage("toggleRecordingShortcut") private var toggleShortcut = "⌃P"
+    @AppStorage("cancelRecordingShortcut") private var cancelShortcut = "⌃K"
     
     var body: some View {
         VStack(spacing: 24) {

--- a/AiTranscribe/AiTranscribe/WelcomeOnboardingView.swift
+++ b/AiTranscribe/AiTranscribe/WelcomeOnboardingView.swift
@@ -21,6 +21,7 @@ struct WelcomeOnboardingView: View {
     /// Track backend readiness state
     @State private var isWaitingForBackend = true
     @State private var dotCount = 0
+    @State private var waitTime: TimeInterval = 0
 
     private let timer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
 
@@ -69,43 +70,31 @@ struct WelcomeOnboardingView: View {
             Spacer()
             Spacer() // Extra spacer to push button down consistently
             
-            // Get Started Button (or Loading state)
+            // Get Started Button (always shown — backend starts in background)
             VStack(spacing: 8) {
+                Button(action: onNext) {
+                    HStack {
+                        Text("Get Started")
+                            .font(.title3.weight(.semibold))
+                        Image(systemName: "arrow.right")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .padding(.horizontal, 60)
+
+                // Show backend status beneath the button
                 if isWaitingForBackend {
-                    // Show loading state while waiting for backend
-                    VStack(spacing: 12) {
-                        HStack(spacing: 8) {
-                            ProgressView()
-                                .scaleEffect(0.8)
-                            Text("Starting backend\(String(repeating: ".", count: dotCount))")
-                                .font(.title3.weight(.medium))
-                                .foregroundColor(.secondary)
-                                .frame(width: 180, alignment: .leading)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 14)
-
-                        Text("This may take a minute on first launch")
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .scaleEffect(0.6)
+                        Text("Backend starting in background\(String(repeating: ".", count: dotCount))")
                             .font(.caption)
-                            .foregroundStyle(.tertiary)
+                            .foregroundColor(.secondary)
                     }
-                    .padding(.horizontal, 60)
                 } else {
-                    // Backend ready - show Get Started button
-                    Button(action: onNext) {
-                        HStack {
-                            Text("Get Started")
-                                .font(.title3.weight(.semibold))
-                            Image(systemName: "arrow.right")
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 14)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
-                    .padding(.horizontal, 60)
-
-                    // Footer - moved inside button section
                     Text("First time? Let's set up your app.")
                         .font(.footnote)
                         .foregroundColor(.secondary)
@@ -117,14 +106,10 @@ struct WelcomeOnboardingView: View {
         .padding()
         .onReceive(timer) { _ in
             dotCount = (dotCount + 1) % 4
-        }
-        .task {
-            // Wait for backend to be ready
-            while !backendManager.isServerReady {
-                try? await Task.sleep(for: .milliseconds(500))
+            // Update backend readiness (non-blocking)
+            if backendManager.isServerReady {
+                isWaitingForBackend = false
             }
-            // Backend is ready
-            isWaitingForBackend = false
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A powerful macOS menu bar application for local speech-to-text transcription. Ru
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Swift](https://img.shields.io/badge/Swift-5.9+-orange)
 ![Python](https://img.shields.io/badge/Python-3.10+-blue)
-![Version](https://img.shields.io/badge/version-0.1.2-purple)
+![Version](https://img.shields.io/badge/version-0.1.5-purple)
 ![Stars](https://img.shields.io/github/stars/Ljove02/AIT-AiTranscribe-MacOS)
 
 ---
@@ -30,11 +30,19 @@ https://github.com/user-attachments/assets/3f8da9f1-6a4b-483a-96ec-75d6239b5fa8
 - **Menu Bar App** — Lives in your menu bar, always accessible, never in your way.
 - **Multiple AI Models** — NVIDIA Parakeet, OpenAI Whisper (base, small, large-v3, large-v3-turbo), and NVIDIA NeMo with streaming support.
 - **Auto-Paste** — Transcribed text can be pasted automatically at your cursor position right after transcription.
+- **Metal GPU Acceleration** — Whisper models run on Apple Silicon GPU via whisper.cpp, delivering 8-10x faster transcription than CPU-only inference. 10 minutes of audio transcribed in ~2 minutes.
+
+### Session Recording
+
+- **Long-form Recording** — Record sessions of any length (meetings, lectures, interviews). Captures both microphone and system audio simultaneously.
+- **Batch Transcription** — Long recordings are automatically split into RAM-aware chunks and transcribed sequentially with live progress streaming.
+- **Session Management** — View, rename, delete, and re-transcribe sessions. Audio and transcription files stored locally.
+- **Floating Session Indicator** — A capsule-shaped indicator with pulsing red dot and HH:MM:SS timer. Draggable, snaps to 8 screen positions.
 
 ### Smart Model Management
 
 - **Lazy Loading** — Models are not loaded at app startup. When you press the record shortcut, the model loads in the background while you speak. By the time you stop, the transcription is ready.
-- **Idle Unloading** — After 2 minutes of inactivity, the model automatically unloads to free 1-3GB of RAM. Next time you record, it loads again seamlessly.
+- **Idle Unloading** — After 2 minutes of inactivity, the model automatically unloads to free RAM. Next time you record, it loads again seamlessly.
 - **Streaming models excluded** — NeMo streaming models (Nemotron) stay loaded since they need to be instantly available for real-time transcription.
 
 ### Recording
@@ -45,16 +53,16 @@ https://github.com/user-attachments/assets/3f8da9f1-6a4b-483a-96ec-75d6239b5fa8
 
 ### Audio Device Management
 
-- **Microphone Selection** — Pick your preferred microphone from the dropdown. The selection actually works — it uses native CoreAudio to set the input device.
+- **Microphone Selection** — Pick your preferred microphone from the dropdown. Uses native CoreAudio to set the input device.
 - **AirPods Support** — When AirPods connect or disconnect, the device list refreshes automatically. If your selected microphone disappears, the app falls back to the default.
 - **Persistent Selection** — Your preferred microphone is remembered across app restarts.
-- **Device Change Notifications** — macOS notification when the default input device changes, so you always know what mic is active.
+- **Device Change Notifications** — macOS notification when the default input device changes.
 
 ### Transcription History
 
 - All transcriptions are saved locally with timestamp, duration, word count, and which model was used.
+- Tap any entry to view the full transcription text and copy it to clipboard.
 - Search through your transcription history to find past recordings.
-- In future versions: semantic search and a dashboard view for analytics.
 
 ### Customization
 
@@ -62,12 +70,6 @@ https://github.com/user-attachments/assets/3f8da9f1-6a4b-483a-96ec-75d6239b5fa8
 - Sound feedback when recording starts and stops
 - Two audio modes during recording: mute completely, or lower volume by a percentage
 - NeMo library installation support for accessing Parakeet models (guided setup in the app)
-
----
-
-## Roadmap
-
-**Next version — Batch transcription for long audio.** Currently, transcribing very long audio (8+ minutes) can spike RAM usage significantly (up to 11GB for a ~490 second recording). The plan is to split long audio into chunks, transcribe each one sequentially, and stream results back progressively. This keeps memory usage flat regardless of recording length, and lets you see partial results as they come in.
 
 ---
 
@@ -156,15 +158,15 @@ The model loads automatically the first time you record. After 2 minutes of idle
 
 ## Models
 
-| Model             | Download Size | Speed   | Accuracy  | RAM Required |
-| ----------------- | ------------- | ------- | --------- | ------------ |
-| Parakeet TDT 0.6B | ~1.2GB        | Fast    | Excellent | ~3GB         |
-| Whisper Base (EN)  | ~150MB        | Fastest | Good      | ~1GB         |
-| Whisper Small (EN) | ~500MB        | Fast    | Very Good | ~2GB         |
-| Whisper Large v3 Turbo | ~1.5GB   | Medium  | Excellent | ~4GB         |
-| Whisper Large v3   | ~3GB          | Slow    | Best      | ~6GB         |
+| Model             | Download Size | Speed    | Accuracy  | RAM Required | GPU Accelerated |
+| ----------------- | ------------- | -------- | --------- | ------------ | --------------- |
+| Whisper Base (EN)  | ~148MB        | Fastest  | Good      | ~400MB       | Yes (Metal)     |
+| Whisper Small (EN) | ~488MB        | Fast     | Very Good | ~850MB       | Yes (Metal)     |
+| Whisper Large v3 Turbo | ~1.6GB   | Fast     | Excellent | ~1.7GB       | Yes (Metal)     |
+| Whisper Large v3   | ~3.1GB        | Medium   | Best      | ~4GB         | Yes (Metal)     |
+| Parakeet TDT 0.6B | ~1.2GB        | Fast     | Excellent | ~3GB         | No (CPU)        |
 
-Models are downloaded on-demand and stored in `~/.cache/huggingface/hub/`.
+Whisper models use [whisper.cpp](https://github.com/ggml-org/whisper.cpp) with Metal GPU acceleration for 8-10x faster inference on Apple Silicon. Models are downloaded on-demand and stored locally.
 
 ---
 
@@ -198,8 +200,13 @@ AIT-AiTranscribe-MacOS/
 │       ├── AudioRecorder.swift         # Audio recording + CoreAudio device management
 │       ├── MenuBarView.swift           # Menu bar UI
 │       ├── RecordingIndicator.swift    # Floating recording indicator
+│       ├── FloatingIndicatorWindow.swift # macOS 26 display cycle fix
+│       ├── Sessions/                    # Session recording system
+│       │   ├── SessionManager.swift
+│       │   ├── SessionRecorder.swift
+│       │   └── SessionIndicatorView.swift
+│       ├── Settings/                    # Settings UI (modular tabs)
 │       ├── HotkeyManager.swift         # Global keyboard shortcuts
-│       ├── SettingsView.swift          # Settings interface
 │       └── ...
 │
 ├── backend/                      # Python/FastAPI backend
@@ -218,7 +225,7 @@ AIT-AiTranscribe-MacOS/
 
 - **Frontend**: Swift / SwiftUI (macOS native)
 - **Backend**: Python / FastAPI (local HTTP server on port 8765)
-- **AI Models**: NVIDIA NeMo (Parakeet), OpenAI Whisper via faster-whisper, CTranslate2
+- **AI Models**: OpenAI Whisper via [whisper.cpp](https://github.com/ggml-org/whisper.cpp) (Metal GPU), NVIDIA NeMo (Parakeet)
 - **Audio**: AVFoundation + CoreAudio (Swift), sounddevice (Python)
 - **Communication**: HTTP + Server-Sent Events (SSE) for streaming progress
 
@@ -269,9 +276,9 @@ This project is licensed under the MIT License — see the [LICENSE](LICENSE) fi
 
 ## Acknowledgments
 
-- [NVIDIA NeMo](https://github.com/NVIDIA/NeMo) for Parakeet models
+- [whisper.cpp](https://github.com/ggml-org/whisper.cpp) for Metal-accelerated Whisper inference
 - [OpenAI Whisper](https://github.com/openai/whisper) for Whisper models
-- [faster-whisper](https://github.com/guillaumekln/faster-whisper) for optimized CTranslate2 inference
+- [NVIDIA NeMo](https://github.com/NVIDIA/NeMo) for Parakeet models
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://github.com/user-attachments/assets/3f8da9f1-6a4b-483a-96ec-75d6239b5fa8
 ### Core
 
 - **100% Local and Private** — All processing happens on your Mac. No internet, no cloud, no data leaves your machine.
-- **Global Hotkey** — Press `Option + Space` from any app to start recording. Press again to stop. The transcription is in your clipboard before you can blink.
+- **Global Hotkey** — Press `Control + P` from any app to start recording. Press again to stop. The transcription is in your clipboard before you can blink.
 - **Menu Bar App** — Lives in your menu bar, always accessible, never in your way.
 - **Multiple AI Models** — NVIDIA Parakeet, OpenAI Whisper (base, small, large-v3, large-v3-turbo), and NVIDIA NeMo with streaming support.
 - **Auto-Paste** — Transcribed text can be pasted automatically at your cursor position right after transcription.
@@ -148,7 +148,7 @@ cp -R dist/AiTranscribe.app /Applications/
    - **Parakeet TDT 0.6B** — Recommended. Best balance of speed and accuracy.
    - **Whisper Base (English)** — Lightweight, good for quick transcriptions.
    - **Whisper Large v3** — Highest accuracy, requires more RAM.
-3. Press `Option + Space` to start recording
+3. Press `Control + P` to start recording
 4. Speak into your microphone
 5. Press the hotkey again to stop — text is in your clipboard
 

--- a/backend/build_standalone.sh
+++ b/backend/build_standalone.sh
@@ -40,6 +40,23 @@ else
 fi
 
 echo ""
+
+# Check if whisper-cli exists
+if [ ! -f "bin/whisper-cli" ]; then
+    echo "WARNING: bin/whisper-cli not found!"
+    echo "Whisper models will not work without it."
+    echo "Build it with:"
+    echo "  git clone https://github.com/ggml-org/whisper.cpp /tmp/whisper.cpp"
+    echo "  cd /tmp/whisper.cpp && cmake -B build && cmake --build build -j --config Release"
+    echo "  cp build/bin/whisper-cli $(pwd)/bin/"
+    echo ""
+    read -p "Continue without whisper-cli? (y/N) " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
 echo "Building standalone executable..."
 echo ""
 

--- a/backend/model_manager.py
+++ b/backend/model_manager.py
@@ -721,6 +721,23 @@ def check_nemo_available() -> dict:
         "device": "cpu"
     }
 
+    # PyInstaller bundled mode: NeMo can never work because TorchScript requires
+    # source code access which isn't available in frozen executables. Skip the heavy
+    # import entirely — saves ~2 minutes of matplotlib font cache + NeMo init.
+    import sys
+    if getattr(sys, 'frozen', False) or getattr(sys, '_MEIPASS', None):
+        print("DEBUG: Running in bundled mode — skipping NeMo import (TorchScript limitation)")
+        return result
+
+    # Fast pre-check: skip heavy import if nemo package isn't even installed.
+    try:
+        import importlib.util
+        if importlib.util.find_spec("nemo") is None:
+            print("DEBUG: NeMo package not found (fast check) — skipping heavy import")
+            return result
+    except Exception:
+        pass
+
     try:
         import nemo
         import nemo.collections.asr as nemo_asr
@@ -729,7 +746,6 @@ def check_nemo_available() -> dict:
     except ImportError:
         return result
     except (OSError, RuntimeError, Exception) as e:
-        # PyInstaller builds can't load NeMo due to TorchScript source requirements
         print(f"DEBUG: NeMo not available in bundled mode: {type(e).__name__}")
         return result
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -655,6 +655,7 @@ def _transcribe_whisper(audio_path: str) -> tuple[str, float]:
         capture_output=True,
         text=True,
         timeout=1800,  # 30 min safety net
+        cwd="/tmp",    # explicit cwd — prevents getcwd crash if parent dir was deleted
     )
 
     processing_time = time.time() - start_time

--- a/build_production.sh
+++ b/build_production.sh
@@ -21,7 +21,7 @@ set -e  # Exit on error
 # Get the directory where this script is located (works even when called from different directory)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT="$SCRIPT_DIR"
-VERSION="0.1.2"
+VERSION="0.1.5"
 APP_NAME="AiTranscribe"
 SKIP_BACKEND=false
 
@@ -150,7 +150,7 @@ else
     fi
 
     # Copy backend Python files for NeMo mode (runs server.py with NeMo venv)
-    for pyfile in server.py model_manager.py recorder.py; do
+    for pyfile in server.py model_manager.py recorder.py batch_transcriber.py; do
         if [ -f "backend/$pyfile" ]; then
             cp "backend/$pyfile" "$RESOURCES_DIR/"
             print_success "Copied $pyfile to Resources"
@@ -158,6 +158,18 @@ else
             print_warning "$pyfile not found in backend/"
         fi
     done
+
+    # Copy whisper-cli binary (whisper.cpp Metal GPU transcription)
+    WHISPER_CLI="backend/bin/whisper-cli"
+    if [ -f "$WHISPER_CLI" ]; then
+        cp "$WHISPER_CLI" "$RESOURCES_DIR/"
+        chmod +x "$RESOURCES_DIR/whisper-cli"
+        print_success "whisper-cli copied to Resources"
+    else
+        print_warning "whisper-cli not found at $WHISPER_CLI"
+        echo "  Whisper models will not work without this binary."
+        echo "  Build it with: git clone https://github.com/ggml-org/whisper.cpp /tmp/whisper.cpp && cd /tmp/whisper.cpp && cmake -B build && cmake --build build -j --config Release && cp build/bin/whisper-cli $(pwd)/backend/bin/"
+    fi
 fi
 
 # =============================================================================
@@ -234,6 +246,24 @@ if [ -f "$BUNDLED_NEMO_REQS" ]; then
 else
     print_warning "NeMo requirements NOT found in app bundle!"
     echo "NeMo model installation may not work without this file."
+fi
+
+# Verify whisper-cli is in bundle
+BUNDLED_WHISPER="dist/${APP_NAME}.app/Contents/Resources/whisper-cli"
+if [ -f "$BUNDLED_WHISPER" ]; then
+    print_success "whisper-cli is bundled in app"
+else
+    print_warning "whisper-cli NOT found in app bundle!"
+    echo "Whisper model transcription will not work without this binary."
+fi
+
+# Verify batch_transcriber.py is in bundle
+BUNDLED_BATCH="dist/${APP_NAME}.app/Contents/Resources/batch_transcriber.py"
+if [ -f "$BUNDLED_BATCH" ]; then
+    print_success "batch_transcriber.py is bundled in app"
+else
+    print_warning "batch_transcriber.py NOT found in app bundle!"
+    echo "Session transcription may not work without this file."
 fi
 
 print_success "App copied to: dist/${APP_NAME}.app"


### PR DESCRIPTION
## Summary

- **Fix macOS 26 Tahoe crashes** — NSHostingView triggers re-entrant `_postWindowNeedsDisplay` / `_postWindowNeedsUpdateConstraints` / `_postWindowNeedsLayout` on borderless floating windows, causing SIGABRT. Fixed via method swizzling with ObjC `@try/@catch` that defers updates to the next run loop instead of crashing.
- **Rewrite session indicator to pure Core Animation** — SwiftUI Text inside NSHostingView on borderless windows never renders correctly on M2/macOS 26 (shows "0" instead of "00:00:00", timer never updates). Replaced with CALayer + CATextLayer + CAShapeLayer that composite through GPU, bypassing AppKit's broken display pipeline entirely.
- **Optimize backend startup (~2 min saved)** — NeMo availability check imports NeMo + matplotlib on first `/models` call, taking ~111 seconds only to fail with OSError in PyInstaller bundles. Now detects `sys.frozen` / `sys._MEIPASS` and skips immediately.
- **Change default hotkeys** — Toggle recording: `Control+P`, Cancel: `Control+K` (was Option+Space / Option+Escape).

## New files
- `FloatingIndicatorWindow.swift` — DisplayCycleFix swizzling + FloatingIndicatorWindow marker class
- `ObjCExceptionCatcher.h/.m` — ObjC bridge for `@try/@catch` (Swift can't catch NSException)
- `AiTranscribe-Bridging-Header.h` — Bridging header for ObjC helper

## Other fixes
- `RecordingIndicator` — added `window?.display()` in volume polling for M2 rendering
- `SessionDetailView` — fixed Slider range crash on 8GB Macs
- `AppState` — force `window.display()` on all windows after model fetch
- Onboarding & settings UI adjustments
- README updated for v0.1.5 features

## Test plan
- [x] Tested on M4 MacBook Air, macOS 26.2 Tahoe
- [x] Tested on M2 MacBook Air 8GB, macOS 26.2 Tahoe
- [x] Verify session indicator shows "00:00:00" and counts up on both machines
- [x] Verify recording indicator pulses and updates on M2
- [x] Verify backend starts in ~30s (not ~2.5 min)
- [x] Verify Control+P / Control+K shortcuts work from any app
- [x] Verify onboarding flow shows new shortcut defaults